### PR TITLE
Fix check if document & window are defined

### DIFF
--- a/reconnect.js
+++ b/reconnect.js
@@ -68,7 +68,7 @@ function Reconnect (connection, options) {
 
   function visibility () {
     if (self.reconnecting && !self.connected && !self.connecting) {
-      if (!document.hidden) self.connect()
+      if (typeof document !== 'undefined' && !document.hidden) self.connect()
     }
   }
   function connect () {
@@ -79,7 +79,10 @@ function Reconnect (connection, options) {
   function disconnect () {
     self.disconnect('freeze')
   }
-  if (typeof navigator !== 'undefined') {
+  if (
+    typeof document !== 'undefined' &&
+    typeof window !== 'undefined'
+  ) {
     document.addEventListener('visibilitychange', visibility, false)
     window.addEventListener('focus', connect, false)
     window.addEventListener('online', connect, false)

--- a/reconnect.js
+++ b/reconnect.js
@@ -81,7 +81,9 @@ function Reconnect (connection, options) {
   }
   if (
     typeof document !== 'undefined' &&
-    typeof window !== 'undefined'
+    typeof window !== 'undefined' &&
+    document.addEventListener &&
+    window.addEventListener
   ) {
     document.addEventListener('visibilitychange', visibility, false)
     window.addEventListener('focus', connect, false)


### PR DESCRIPTION
Okay this seems to be working fine

I removed the `typeof navigator !== 'undefined'` as it shouldn't be necessary anymore, right?