### PR TITLE
Add test to LoguxError, do not crash if captureStackTrace does not exist

### DIFF
--- a/logux-error/index.test.js
+++ b/logux-error/index.test.js
@@ -10,6 +10,13 @@ function catchError (desc, type, received) {
   return error
 }
 
+it('does not crash if captureStackTrace does not exist', () => {
+  let captureStackTrace = global.Error.captureStackTrace
+  delete global.Error.captureStackTrace
+  catchError('test')
+  global.Error.captureStackTrace = captureStackTrace
+})
+
 it('has stack trace', () => {
   let error = catchError('test')
   expect(error.stack).toContain('index.test.js')


### PR DESCRIPTION
If error doesn't has `captureStackTrace` the application shouldn't crash
<img width="353" alt="Screen Shot 2020-03-29 at 08 53 35" src="https://user-images.githubusercontent.com/48512663/77843164-ca3b2f00-719a-11ea-9321-2ab81074763a.png">
