### PR TITLE
Add headers command

### DIFF
--- a/base-node/index.d.ts
+++ b/base-node/index.d.ts
@@ -203,6 +203,12 @@ export class BaseNode<M extends Meta = Meta> {
   /**
    * Headers set by remote node.
    * By default, it is an empty object.
+   * 
+   * ```js
+   * if (Object.keys(node.remoteHeaders).length > 0) {
+   *   console.log(`Headers set by remote node:`, node.remoteHeaders)
+   * }
+   * ```
    */
   remoteHeaders: object
 
@@ -364,7 +370,7 @@ export class BaseNode<M extends Meta = Meta> {
   /**
    * Set headers for current node. 
    * 
-   * @param headers
+   * @param headers The data object will be set as headers for current node.
    */
   setLocalHeaders (headers: object): void
 }

--- a/base-node/index.d.ts
+++ b/base-node/index.d.ts
@@ -59,13 +59,14 @@ export abstract class Connection {
    * * `disconnect`: connection was closed by any side.
    * * `message`: message was receive from remote node.
    * * `error`: error during connection, sending or receiving.
+   * * `headers`: headers was receive from remote node.
    *
    * @param event Event name.
    * @param listener Event listener.
    * @returns Unbind listener from event.
    */
   on (
-    event: 'connecting' | 'connect' | 'disconnect' | 'message' | 'error',
+    event: 'connecting' | 'connect' | 'disconnect' | 'message' | 'error' | 'headers',
     listener: () => void
   ): Unsubscribe
 
@@ -197,6 +198,13 @@ export class BaseNode<M extends Meta = Meta> {
    * ```
    */
   remoteSubprotocol: string | undefined
+
+
+  /**
+   * Headers set by remote node.
+   * By default, it is an empty object.
+   */
+  remoteHeaders: object
 
   /**
    * Minimum version of Logux protocol, which is supported.
@@ -351,4 +359,12 @@ export class BaseNode<M extends Meta = Meta> {
    * ```
    */
   destroy (): void
+
+
+  /**
+   * Set headers for current node. 
+   * 
+   * @param headers
+   */
+  setLocalHeaders (headers: object): void
 }

--- a/base-node/index.d.ts
+++ b/base-node/index.d.ts
@@ -4,7 +4,7 @@ import { LoguxError, LoguxErrorOptions } from '../logux-error'
 import { Log, Action, Meta } from '../log'
 
 interface Authentificator {
-  (nodeId: string, token: string): Promise<boolean>
+  (nodeId: string, token: string, headers: object): Promise<boolean>
 }
 
 interface Filter {
@@ -30,7 +30,8 @@ type Message =
   // Inaccurate type until https://github.com/microsoft/TypeScript/issues/26113
   ['sync', number, object, object] |
   ['synced', number] |
-  ['debug', 'error', string]
+  ['debug', 'error', string] |
+  ['headers', object]
 
 /**
  * Abstract interface for connection to synchronize logs over it.

--- a/base-node/index.js
+++ b/base-node/index.js
@@ -9,6 +9,7 @@ let {
 let { sendPing, pingMessage, pongMessage } = require('../ping')
 let { sendDebug, debugMessage } = require('../debug')
 let { sendError, errorMessage } = require('../error')
+let { sendHeaders, headersMessage } = require('../headers')
 let { LoguxError } = require('../logux-error')
 
 const NOT_TO_THROW = {
@@ -17,7 +18,7 @@ const NOT_TO_THROW = {
   'timeout': true
 }
 
-const BEFORE_AUTH = ['connect', 'connected', 'error', 'debug']
+const BEFORE_AUTH = ['connect', 'connected', 'error', 'debug', 'headers']
 
 async function syncMappedEvent (node, action, meta) {
   let added = meta.added
@@ -100,6 +101,8 @@ class BaseNode {
     this.initialized = false
     this.lastAddedCache = 0
     this.initializing = this.initialize()
+    this.localHeaders = {}
+    this.remoteHeaders = {}
   }
 
   on (event, listener) {
@@ -339,6 +342,13 @@ class BaseNode {
       this.send(['duilian', DUILIANS[line]])
     }
   }
+
+  setLocalHeaders (data) {
+    this.localHeaders = data
+    if (this.connected) {
+      this.sendHeaders(data)
+    }
+  }
 }
 
 BaseNode.prototype.sendConnect = sendConnect
@@ -360,6 +370,9 @@ BaseNode.prototype.debugMessage = debugMessage
 
 BaseNode.prototype.sendError = sendError
 BaseNode.prototype.errorMessage = errorMessage
+
+BaseNode.prototype.sendHeaders = sendHeaders
+BaseNode.prototype.headersMessage = headersMessage
 
 const DUILIANS = {
   金木水火土: '板城烧锅酒'

--- a/base-node/index.js
+++ b/base-node/index.js
@@ -343,10 +343,10 @@ class BaseNode {
     }
   }
 
-  setLocalHeaders (data) {
-    this.localHeaders = data
+  setLocalHeaders (headers) {
+    this.localHeaders = headers
     if (this.connected) {
-      this.sendHeaders(data)
+      this.sendHeaders(headers)
     }
   }
 }

--- a/connect/index.js
+++ b/connect/index.js
@@ -8,7 +8,7 @@ async function auth (node, nodeId, token, callback) {
   }
 
   try {
-    let access = await node.options.auth(nodeId, token)
+    let access = await node.options.auth(nodeId, token, node.remoteHeaders)
     if (access) {
       node.authenticated = true
       callback()
@@ -80,6 +80,11 @@ async function sendConnect () {
   if (Object.keys(options).length > 0) message.push(options)
 
   if (this.options.fixTime) this.connectSended = this.now()
+
+  if (Object.keys(this.localHeaders).length > 0) {
+    this.sendHeaders(this.localHeaders)
+  }
+
   this.startTimeout()
   this.send(message)
 }
@@ -104,6 +109,10 @@ async function sendConnected (start, end) {
     options.subprotocol = this.options.subprotocol
   }
   if (Object.keys(options).length > 0) message.push(options)
+
+  if (Object.keys(this.localHeaders).length > 0) {
+    this.sendHeaders(this.localHeaders)
+  }
 
   this.send(message)
 }

--- a/headers/index.js
+++ b/headers/index.js
@@ -1,0 +1,10 @@
+function sendHeaders (data) {
+  this.send(['headers', data])
+}
+
+function headersMessage (data) {
+  this.remoteHeaders = data
+  this.emitter.emit('headers', data)
+}
+
+module.exports = { sendHeaders, headersMessage }

--- a/headers/index.test.js
+++ b/headers/index.test.js
@@ -1,0 +1,53 @@
+let { ServerNode, TestTime, TestPair } = require('..')
+
+let node
+
+afterEach(() => {
+  if (node) {
+    node.destroy()
+    node = undefined
+  }
+})
+
+async function createTestPair () {
+  let pair = new TestPair()
+  node = new ServerNode('server', TestTime.getLog(), pair.left)
+  pair.leftNode = node
+  await pair.left.connect()
+
+  return pair
+}
+
+it('emits a headers on header messages', async () => {
+  let test = await createTestPair()
+
+  let headers = {}
+  test.leftNode.on('headers', data => {
+    headers = data
+  })
+
+  test.leftNode.onMessage(['headers', { test: 'test' }])
+
+  expect(headers).toEqual({ test: 'test' })
+})
+
+it('checks types', async () => {
+  let wrongs = [
+    ['headers'],
+    ['headers', true],
+    ['headers', 0],
+    ['headers', []],
+    ['headers', 'abc'],
+    ['headers', {}, 'abc']
+  ]
+  await Promise.all(wrongs.map(async command => {
+    let test = await createTestPair()
+    test.right.send(command)
+    await test.wait('right')
+    expect(test.leftNode.connected).toBe(false)
+    expect(test.leftSent).toEqual([
+      ['error', 'wrong-format', JSON.stringify(command)]
+    ])
+    node.destroy()
+  }))
+})

--- a/validate/index.js
+++ b/validate/index.js
@@ -80,6 +80,10 @@ let validators = {
   debug (msg) {
     return (msg.length === 3) && isString(msg[1]) &&
            (msg[1] === 'error' && isString(msg[2]))
+  },
+
+  headers (msg) {
+    return (msg.length === 2) && isObject(msg[1])
   }
 
 }


### PR DESCRIPTION
This pull request cover new protocol command added in https://github.com/logux/docs/pull/60

I'm opening this PR as draft because I'm not finished it yet. 
I have a problem with writing test:

```
  await test.left.connect()
  test.leftNode.sendHeaders({ env: 'development' })
  await test.wait('right')
```
If I'm trying send headers before the connect command then test is failed because of timeout.

@ai Could you please help me with tests?
