### PR TITLE
Fixes the log.each signature in typings.

### DIFF
--- a/log/index.d.ts
+++ b/log/index.d.ts
@@ -329,11 +329,32 @@ export class Log<M extends Meta = Meta> {
    * })
    * ```
    *
-   * @param opts Iterator options.
    * @param callback Function will be executed on every action.
    * @returns When iteration will be finished by iterator or end of actions.
    */
   each (callback: ActionIterator<M>): Promise<void>
+
+  /**
+   * Iterates through all actions, from last to first.
+   *
+   * Return false from callback if you want to stop iteration.
+   *
+   * ```js
+   * log.each({ order: 'created' }, (action, meta) => {
+   *   if (compareTime(meta.id, lastBeep) <= 0) {
+   *     return false;
+   *   } else if (action.type === 'beep') {
+   *     beep()
+   *     lastBeep = meta.id
+   *     return false;
+   *   }
+   * })
+   * ```
+   *
+   * @param opts Iterator options.
+   * @param callback Function will be executed on every action.
+   * @returns When iteration will be finished by iterator or end of actions.
+   */
   each (opts: GetOptions, callback: ActionIterator<M>): Promise<void>
 
   /**

--- a/log/index.d.ts
+++ b/log/index.d.ts
@@ -333,6 +333,7 @@ export class Log<M extends Meta = Meta> {
    * @param callback Function will be executed on every action.
    * @returns When iteration will be finished by iterator or end of actions.
    */
+  each (callback: ActionIterator<M>): Promise<void>
   each (opts: GetOptions, callback: ActionIterator<M>): Promise<void>
 
   /**


### PR DESCRIPTION
`client.log.each` can actually accept one parameter instead of two. PR adds this signature to the typings.