### PR TITLE
fix(base-node): listener error can be LoguxError

### DIFF
--- a/base-node/index.d.ts
+++ b/base-node/index.d.ts
@@ -362,7 +362,7 @@ export class BaseNode<H extends object = {}, L extends Log = Log<Meta>> {
 
   on (
     event: 'error' | 'clientError',
-    listener: (error: Error | LoguxError) => void
+    listener: (error: LoguxError) => void
   ): Unsubscribe
 
   on (

--- a/base-node/index.d.ts
+++ b/base-node/index.d.ts
@@ -362,7 +362,7 @@ export class BaseNode<H extends object = {}, L extends Log = Log<Meta>> {
 
   on (
     event: 'error' | 'clientError',
-    listener: (error: Error) => void
+    listener: (error: Error | LoguxError) => void
   ): Unsubscribe
 
   on (


### PR DESCRIPTION
```ts
client.node.on('error', error => {
  // THROWS Property 'type' does not exist on type 'Error'.
  if (error.type === 'wrong-credentials') {
    // …
  }
})
```