### PR TITLE
fix: await in sequence

### DIFF
--- a/sync/index.js
+++ b/sync/index.js
@@ -39,8 +39,8 @@ export function sendSynced(added) {
 
 export async function syncMessage(added, ...data) {
   for (let i = 0; i < data.length - 1; i += 2) {
-    const action = data[i]
-    const meta = data[i + 1]
+    let action = data[i]
+    let meta = data[i + 1]
 
     if (typeof meta.id === 'number') {
       meta.id = meta.id + this.baseTime + ' ' + this.remoteNodeId + ' ' + 0

--- a/sync/index.js
+++ b/sync/index.js
@@ -38,11 +38,9 @@ export function sendSynced(added) {
 }
 
 export async function syncMessage(added, ...data) {
-  let promises = []
-
   for (let i = 0; i < data.length - 1; i += 2) {
-    let action = data[i]
-    let meta = data[i + 1]
+    const action = data[i]
+    const meta = data[i + 1]
 
     if (typeof meta.id === 'number') {
       meta.id = meta.id + this.baseTime + ' ' + this.remoteNodeId + ' ' + 0
@@ -70,7 +68,7 @@ export async function syncMessage(added, ...data) {
         })
     }
 
-    process
+    await process
       .then(filtered => {
         if (filtered && this.options.inFilter) {
           return this.options
@@ -90,11 +88,8 @@ export async function syncMessage(added, ...data) {
         if (this.received) this.received[changed[1].id] = true
         return this.log.add(changed[0], changed[1])
       })
-
-    promises.push(process)
   }
 
-  await Promise.all(promises)
   this.setLastReceived(added)
   this.sendSynced(added)
 }


### PR DESCRIPTION
It's critical that any list of messages coming in are added to the log in the right order.

We have channels/actions that write this incoming data into the database upon adding to the log. 
It can potentially run out of order because we run lines 74-78: https://github.com/logux/core/blob/0a021beaffa01fc5a602ad3d59d35c0cfb8d4708/sync/index.js#L74-L81

the `inFilter` is actually another promise, and on `logux/server`, it awaits `processor.access`:
https://github.com/logux/server/blob/63337798eea393fbeee1c6cb519bce3ae71ef354/server-client/index.js#L214

This means the `this.log.add` and subsequent `processor.process` could be out of order.

