### PR TITLE
fix: reset syncing on disconnect

### DIFF
--- a/base-node/index.js
+++ b/base-node/index.js
@@ -183,6 +183,7 @@ export class BaseNode {
     if (this.pingTimeout) clearTimeout(this.pingTimeout)
     this.authenticated = false
     this.connected = false
+    this.syncing = 0
     this.setState('disconnected')
   }
 


### PR DESCRIPTION
I have another edge case/race condition to fix. If the user sends an action to the server and disconnects before receiving a "synced" message back, the clientNode's internal `this.syncing` counter will never reach 0, even after they reconnect.

This means after reconnecting, they will never be in a 'synchronized' state, and will never resubscribe because of this code: https://github.com/voiceflow/logux-client/blob/53bf1f0e29ffb9cea7add38ed3669289fe6377b2/client/index.js#L257-L272

We can set `syncing = 0` in disconnected