### PR TITLE
fix browser `freeze`/`resume` event handling by client Reconnect

### DIFF
--- a/reconnect/index.test.ts
+++ b/reconnect/index.test.ts
@@ -304,7 +304,7 @@ test('has dynamic delay', () => {
 
 test('listens for window events', async () => {
   let pair = new TestPair()
-  let recon = new Reconnect(pair.left)
+  let recon = new Reconnect(pair.left, {maxDelay: 0})
 
   await recon.connect()
   pair.right.disconnect()
@@ -320,6 +320,8 @@ test('listens for window events', async () => {
   is(recon.connected, true)
 
   listeners.freeze()
+  await delay(10)
+
   is(recon.connecting, false)
   is(recon.connected, false)
 


### PR DESCRIPTION
https://developer.chrome.com/blog/page-lifecycle-api/#state-frozen

While freeze event, e.g.
`window.dispatchEvent(new Event('freeze'))`
should pause logux until
`window.dispatchEvent(new Event('resume'))`
But in current implementation it will reconnect because of on('disconnect') handler.

I think that can be related to a part of timeouts plethora as browser (current Chrome) reconnects after `freeze` but timers should essentially be sleeping. Not sure if it that prevents browser from freezing.

Kinda offtopic but interesting findings on browser freeze workarounds from SignalR team: https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/signalr/javascript-client.md#browser-sleeping-tab