### PR TITLE
FIX: types for lastSynced

### DIFF
--- a/log/index.d.ts
+++ b/log/index.d.ts
@@ -239,7 +239,7 @@ export abstract class LogStore {
    * @param values Object with latest sent or received values.
    * @returns Promise when values will be saved to store.
    */
-  setLastSynced(values: LastSynced): Promise<void>
+  setLastSynced(values: Partial<LastSynced>): Promise<void>
 }
 
 interface LogOptions<Store extends LogStore = LogStore> {


### PR DESCRIPTION
In `baseNode`, [we call `this.log.store.setLastSynced`](https://github.com/logux/core/blob/main/base-node/index.js#L255) with `{ received: number }`. But the types for this method [require an argument like `{ received: number, sent: number }`](https://github.com/logux/core/blob/main/log/index.d.ts#L242).

Should this use a different type, so that you do not have to pass in a `sent` property?